### PR TITLE
setup: link libnpymath

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,17 +2,19 @@ from os.path import join
 import numpy as np
 
 def configuration(parent_package='', top_path=None):
-    from numpy.distutils.misc_util import Configuration
+    from numpy.distutils.misc_util import Configuration, get_info
 
     config = Configuration(None, parent_package, top_path)
     config.add_subpackage('numtypes')
     config.add_subpackage('numtypes/tests')
     config.add_extension('numtypes._nint',
                          extra_compile_args=['-std=c99'],
-                         sources=[join('src', '_nint.c.src')])
+                         sources=[join('src', '_nint.c.src')],
+                         **get_info("npymath"))
     config.add_extension('numtypes._complex_int',
                          extra_compile_args=['-std=c99'],
-                         sources=[join('src', '_complex_int.c.src')])
+                         sources=[join('src', '_complex_int.c.src')],
+                         **get_info("npymath"))
     config.add_extension('numtypes._polarcomplex',
                          extra_compile_args=['-std=c99'],
                          sources=[join('src', '_polarcomplex.c.src')])


### PR DESCRIPTION
Hello,

I experienced runtime issues coming from missing symbols defined in numpy's `libnpymath`. This also appears in the CI runs.

Linking it explicitly solves the issue, as proposed in this PR.

Thanks for your time and consideration.